### PR TITLE
Wire up all tool plugins and fix README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 .gitconfig
+__pycache__/
+*.pyc
+.DS_Store
+venv/
+venv310/
+*.egg-info/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/
 venv310/
 *.egg-info/
 .env
+hydra_output.json

--- a/README.md
+++ b/README.md
@@ -1,197 +1,168 @@
-# Model Context Provider (MCP) for Penetration Testing
+# MCP Pentest Server
 
 <div align="center">
-  <img src="docs/images/mcp-logo.png" alt="MCP Logo" width="300" />
-  <br>
-  <em>An AI-driven assistant and middleware for penetration testing engagements</em>
+  <em>An MCP server that exposes penetration testing tools to AI assistants</em>
   <br><br>
-  
+
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
   [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
-  [![Docker](https://img.shields.io/badge/docker-supported-blue.svg)](https://www.docker.com/)
-  [![Status: WIP](https://img.shields.io/badge/Status-Work%20In%20Progress-orange)](https://github.com/yourusername/mcp-pentest)
+  [![MCP](https://img.shields.io/badge/MCP-Compatible-green.svg)](https://modelcontextprotocol.io/)
 </div>
 
-## ⚠️ Work In Progress - Contributors Wanted!
+## What is this?
 
-**MCP is currently under active development and in alpha stage.** We're looking for contributors to help build out this exciting project! Whether you're interested in:
+An MCP (Model Context Protocol) server that lets AI assistants like Claude run penetration testing tools. Ask Claude to "scan this host with nmap" and it will execute the scan and return structured results.
 
-- Implementing new tool integrations
-- Improving the AI assistant's capabilities
-- Enhancing the UI/UX
-- Writing documentation
-- Testing the system
+**Contributors welcome!** See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started.
 
-Your contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started.
+> **Disclaimer**: This tool is intended for legal security testing with proper authorization. Misuse of this software for unauthorized access to systems is illegal and unethical.
 
-## 🔍 Overview
+## Features
 
-The Model Context Provider (MCP) is an open-source framework that bridges AI with penetration testing tools. MCP interfaces with a wide array of pentesting tools, parses and enriches their output in real-time, and strictly follows the standard penetration testing process. It guides human pentesters through each phase – from reconnaissance and scanning to exploitation, post-exploitation, and reporting – aligning with established methodologies.
+- **7 MCP Tools**: nmap, gobuster, nikto, hydra, john, metasploit, and event retrieval
+- **Structured Output**: Tool results are parsed into typed events (HostDiscovered, PortFound, ServiceDetected, VulnerabilityFound, etc.)
+- **Event Storage**: Scan results are stored and queryable during the session
+- **AI-Friendly**: Designed for use with Claude Desktop or any MCP-compatible client
 
-> ⚠️ **Disclaimer**: This tool is intended for legal security testing with proper authorization. Misuse of this software for unauthorized access to systems is illegal and unethical.
+## Architecture
 
-## ✨ Key Features
+```
+┌─────────────────┐     MCP Protocol      ┌──────────────────────┐
+│  Claude Desktop │◄────────────────────►│   MCP Pentest Server │
+│  or MCP Client  │        stdio          │      (server.py)     │
+└─────────────────┘                       └──────────┬───────────┘
+                                                     │
+                                          ┌──────────┴───────────┐
+                                          │    Tool Plugins      │
+                                          ├──────────────────────┤
+                                          │ • NmapPlugin         │
+                                          │ • GobusterPlugin     │
+                                          │ • NiktoPlugin        │
+                                          │ • HydraPlugin        │
+                                          │ • JohnPlugin         │
+                                          │ • MetasploitPlugin   │
+                                          └──────────┬───────────┘
+                                                     │
+                                          ┌──────────┴───────────┐
+                                          │   External Tools     │
+                                          │  (nmap, gobuster...) │
+                                          └──────────────────────┘
+```
 
-- **Methodology Enforcement**: Ensures each engagement progresses through proper phases (reconnaissance → scanning → exploitation → post-exploitation → reporting) in order.
-- **Real-time Context Aggregation**: Captures tool outputs, normalizes the data into a unified engagement context, and stores it for analysis.
-- **LLM-Powered Insights**: Leverages a large language model to interpret findings and provide guidance during the engagement.
-- **Seamless Tool Integration**: Acts as a middleware layer that hooks into major pentest tools, converting their results into a common event format.
-- **Secure Data Handling**: Enforces strict security on processed data, including sanitization when interacting with the LLM.
-- **Reporting and Knowledge Retention**: Logs all findings and actions in a structured format for report generation.
+- **Single Python server** communicating via MCP protocol over stdio
+- **Plugin-based**: Each tool has a plugin that builds commands, executes, and parses output
+- **Event-driven**: Tool outputs are parsed into structured events stored in memory
 
-## 🏗️ Architecture
+## Available Tools
 
-MCP is built on a microservices-based, event-driven system deployed in a containerized environment:
+| Tool | MCP Command | Description | Required |
+|------|-------------|-------------|----------|
+| [Nmap](https://nmap.org/) | `nmap_scan` | Network discovery, port scanning, service detection | Recommended |
+| [Gobuster](https://github.com/OJ/gobuster) | `gobuster_scan` | Directory and file brute forcing | Optional |
+| [Nikto](https://github.com/sullo/nikto) | `nikto_scan` | Web server vulnerability scanner | Optional |
+| [Hydra](https://github.com/vanhauser-thc/thc-hydra) | `hydra_attack` | Network login brute-force | Optional |
+| [John the Ripper](https://www.openwall.com/john/) | `john_crack` | Offline password hash cracking | Optional |
+| [Metasploit](https://www.metasploit.com/) | `metasploit_exploit` | Exploitation framework (requires msfrpcd) | Optional |
+| - | `get_scan_events` | Retrieve stored scan events | Built-in |
 
-- **Core Context Processing Engine**: Central brain that aggregates and normalizes data from all tools
-- **AI-Powered Attack Path Analyzer**: Identifies potential attack paths and prioritizes targets
-- **Plugin-Based Integration Framework**: Extensible system for interfacing with external tools
-- **Secure Logging & Reporting Module**: Maintains engagement logs and produces reports
-- **Real-Time LLM Query Interface**: Provides natural language interface for querying findings
-- **Role-Based Access Control**: Enforces security across all operations
+> **Note**: Tools are optional. The MCP server will work with whatever tools you have installed. Missing tools will return an error when called.
 
-## 🧰 Integrated Tools
-
-MCP currently integrates with the following tools:
-
-### Network Scanning & Enumeration
-- [Nmap](https://nmap.org/): Network discovery and security auditing
-- [Masscan](https://github.com/robertdavidgraham/masscan): High-speed port scanner
-
-### Web Enumeration
-- [Gobuster](https://github.com/OJ/gobuster): Directory and file brute forcing
-- [Nikto](https://github.com/sullo/nikto): Web server scanner for vulnerabilities
-
-### Exploitation & Post-Exploitation
-- [Metasploit Framework](https://www.metasploit.com/): Exploitation framework
-
-### Password Attacks
-- [Hydra](https://github.com/vanhauser-thc/thc-hydra): Network login brute-force tool
-- [John the Ripper](https://www.openwall.com/john/): Offline password cracker
-
-### Privilege Escalation
-- [LinPEAS](https://github.com/carlospolop/PEASS-ng): Linux Privilege Escalation enumeration script
-
-## 🚀 Getting Started
+## Getting Started
 
 ### Prerequisites
 
-- Python 3.8+
-- Nmap (for network scanning)
-- Gobuster (for web enumeration) 
-- Proper authorizations and scope definitions for penetration testing
+- Python 3.10+
+- At least one pentest tool installed (nmap recommended)
+- Proper authorization for any systems you test
 
 ### Installation
 
-1. Clone this repository:
+1. Clone and set up:
 ```bash
 git clone https://github.com/allsmog/mcp-pentest.git
 cd mcp-pentest
-```
 
-2. Install the MCP server:
-```bash
-pip install -e .
-```
+# Create virtual environment
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
 
-3. Install required dependencies:
-```bash
+# Install dependencies
 pip install mcp
 ```
 
-### Testing with Claude Desktop
+2. Install pentest tools (install what you need):
+```bash
+# macOS (Homebrew)
+brew install nmap hydra gobuster
 
-1. Add this MCP server to your Claude Desktop configuration. Edit your `claude_desktop_config.json`:
+# Ubuntu/Debian
+sudo apt install nmap hydra gobuster nikto
+```
+
+### Usage with Claude Desktop
+
+Add to your `claude_desktop_config.json`:
 
 ```json
 {
   "mcpServers": {
     "mcp-pentest": {
-      "command": "python",
+      "command": "/path/to/mcp-pentest/venv/bin/python",
       "args": ["/path/to/mcp-pentest/server.py"],
-      "env": {}
+      "env": {
+        "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+      }
     }
   }
 }
 ```
 
-2. Restart Claude Desktop
+Restart Claude Desktop, then try:
+- "Run an nmap scan on 192.168.1.1"
+- "Scan ports 80,443,8080 on 10.0.0.1"
+- "Show me the scan events"
 
-3. You should now see the penetration testing tools available in Claude Desktop. Try commands like:
-   - "Run an nmap scan on 127.0.0.1"
-   - "Perform a gobuster directory scan on https://httpbin.org"
-   - "Show me the latest scan events"
-
-### Manual Testing
-
-You can also test the server directly:
+### Testing
 
 ```bash
-# Run the MCP server
-python server.py
+# Activate virtual environment
+source venv/bin/activate
 
-# The server will communicate via stdio using the MCP protocol
+# Run the test suite
+python test_mcp_server.py
 ```
 
-See our [documentation](docs/API_SPECIFICATION.md) for complete API references and examples.
+## Roadmap
 
-## 📋 Project Roadmap
+**Done:**
+- [x] MCP server implementation
+- [x] Nmap, Gobuster, Nikto, Hydra, John, Metasploit plugins
+- [x] Event parsing and storage
+- [x] Basic test suite
 
-Here's what we're currently working on:
+**TODO:**
+- [ ] Persistent event storage (currently in-memory only)
+- [ ] Report generation
+- [ ] Additional tool plugins (masscan, sqlmap, etc.)
+- [ ] Web UI for viewing results
 
-- [ ] Completing core Context Engine implementation
-- [ ] Finishing initial tool integrations
-- [ ] Building the AI-powered attack path analyzer
-- [ ] Developing the web UI
-- [ ] Creating comprehensive test suite
-- [ ] Adding additional tool integrations
-- [ ] Implementing report generation
+Contributions welcome!
 
-We welcome contributions to any of these areas!
+## Contributing
 
-## 🤝 Contributing
+Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Contributions are welcome and appreciated! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+**Ways to help:**
+- Add new tool plugins (see [Tool Integration Guide](docs/TOOL_INTEGRATION.md))
+- Test and report bugs
+- Improve documentation
 
-### How You Can Help
+## License
 
-We're particularly looking for help with:
+MIT License - see [LICENSE](LICENSE).
 
-1. **Tool Integrations**: Adding support for more security tools
-2. **Testing**: Real-world testing and bug reporting
-3. **Documentation**: Improving and expanding guides
-4. **UI Development**: Building the web interface
-5. **AI Components**: Enhancing LLM integration and attack path analysis
+## Security
 
-### Adding New Tool Integrations
-
-We especially welcome contributions for new tool integrations. See our [Tool Integration Guide](docs/TOOL_INTEGRATION.md) for how to add support for additional tools.
-
-## 💬 Community
-
-- **Issues**: Use GitHub issues for bug reports and feature requests
-- **Discussions**: GitHub discussions for general questions and ideas
-
-## 📜 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 🔐 Security Considerations
-
-Given the nature of this tool, please be especially mindful of security:
-
-- Never commit credentials, API keys, or sensitive information
-- Always follow responsible disclosure practices
-- Ensure proper authorization before testing any systems
-
-## 📚 Documentation
-
-- [API Reference](docs/API_SPECIFICATION.md)
-- [Architecture Guide](docs/ARCHITECTURE.md)
-- [Tool Integration Guide](docs/TOOL_INTEGRATION.md)
-- [Deployment Guide](docs/DEPLOYMENT.md)
-
-## 🙏 Acknowledgments
-
-- Thanks to all the open-source penetration testing tools this project builds upon
-- Special recognition to the security researchers and tool developers who inspire this work
+- Never commit credentials or API keys
+- Only test systems you have authorization to test
+- Follow responsible disclosure practices

--- a/mcp-pentest-flowchart.drawio
+++ b/mcp-pentest-flowchart.drawio
@@ -1,0 +1,242 @@
+<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36" version="28.0.6">
+  <diagram name="MCP-Pentest-Flow" id="mcp-pentest-architecture">
+    <mxGraphModel dx="2857" dy="1889" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1200" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="ui-layer" value="User Interface Layer" style="swimlane;fillColor=#e1f5e1;strokeColor=#82b366;startSize=30;fontSize=14;fontStyle=1" parent="1" vertex="1">
+          <mxGeometry x="-150" y="40" width="540" height="200" as="geometry" />
+        </mxCell>
+        <mxCell id="user" value="User in AI Chat" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" parent="ui-layer" vertex="1">
+          <mxGeometry x="10" y="50" width="140" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="claude-ai" value="AI Assistant" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" parent="ui-layer" vertex="1">
+          <mxGeometry x="310" y="50" width="140" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="mcp-client" value="MCP Client Interface" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" parent="ui-layer" vertex="1">
+          <mxGeometry x="100" y="130" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="protocol-layer" value="MCP Protocol Layer" style="swimlane;fillColor=#ffe1e1;strokeColor=#d79b00;startSize=30;fontSize=14;fontStyle=1" parent="1" vertex="1">
+          <mxGeometry x="420" y="40" width="370" height="200" as="geometry" />
+        </mxCell>
+        <mxCell id="mcp-server" value="MCP Pentest Server" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" parent="protocol-layer" vertex="1">
+          <mxGeometry x="100" y="50" width="140" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="list-tools" value="List Available Tools" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" parent="protocol-layer" vertex="1">
+          <mxGeometry x="230" y="140" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="exec-layer" value="Tool Execution Layer" style="swimlane;fillColor=#e1e1ff;strokeColor=#6c8ebf;startSize=30;fontSize=14;fontStyle=1" parent="1" vertex="1">
+          <mxGeometry x="40" y="280" width="740" height="270" as="geometry" />
+        </mxCell>
+        <mxCell id="tool-router" value="Which Tool?" style="rhombus;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="exec-layer" vertex="1">
+          <mxGeometry x="310" y="40" width="100" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="nmap-plugin" value="Nmap Plugin" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="exec-layer" vertex="1">
+          <mxGeometry x="60" y="140" width="120" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="event-retrieval" value="Event Retrieval" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="exec-layer" vertex="1">
+          <mxGeometry x="610" y="140" width="120" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="event-layer" value="Event Processing Layer" style="swimlane;fillColor=#fff5e1;strokeColor=#d6b656;startSize=30;fontSize=14;fontStyle=1" parent="1" vertex="1">
+          <mxGeometry x="800" y="-60" width="750" height="630" as="geometry" />
+        </mxCell>
+        <mxCell id="gobuster-process" value="Gobuster Process" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="event-layer" vertex="1">
+          <mxGeometry x="190" y="40" width="120" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="nmap-parser" value="Nmap Output Parser" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="event-layer" vertex="1">
+          <mxGeometry x="70" y="140" width="120" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="message-broker" value="Message Broker" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" parent="event-layer" vertex="1">
+          <mxGeometry x="450" y="30" width="140" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="event-storage" value="Event Storage" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#fff2cc;strokeColor=#d6b656;" parent="event-layer" vertex="1">
+          <mxGeometry x="640" y="120" width="100" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="event-types-group" value="Event Types" style="group;fontSize=12;fontStyle=1" parent="event-layer" vertex="1" connectable="0">
+          <mxGeometry x="30" y="230" width="720" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="host-discovered" value="HostDiscovered" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;" parent="event-types-group" vertex="1">
+          <mxGeometry y="40" width="120" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="port-found" value="PortFound" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;" parent="event-types-group" vertex="1">
+          <mxGeometry x="140" y="40" width="120" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="service-detected" value="ServiceDetected" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;" parent="event-types-group" vertex="1">
+          <mxGeometry x="280" y="40" width="120" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="vuln-found" value="VulnerabilityFound" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;" parent="event-types-group" vertex="1">
+          <mxGeometry x="420" y="40" width="120" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="web-resource" value="WebResourceDiscovered" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;" parent="event-types-group" vertex="1">
+          <mxGeometry x="560" y="40" width="160" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="format-response" value="Format Response" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="event-types-group" vertex="1">
+          <mxGeometry x="290" y="120" width="140" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="gobuster-parser" value="Gobuster Output Parser" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="event-types-group" vertex="1">
+          <mxGeometry x="130" y="-40" width="120" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="nmap-process" value="Nmap Process" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="event-layer" vertex="1">
+          <mxGeometry x="20" y="40" width="120" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow11" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="event-layer" source="nmap-process" target="nmap-parser" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow10" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="event-layer" source="nmap-process" target="gobuster-process" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow12" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="event-layer" source="gobuster-process" target="gobuster-parser" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow14" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="event-layer" source="gobuster-parser" target="message-broker" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow14-label" value="Generate events" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow14" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="user" target="claude-ai" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow1-label" value="Request pentesting action" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow1" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="claude-ai" target="mcp-client" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow2-label" value="Generates MCP tool call" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow2" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="mcp-client" target="mcp-server" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow3-label" value="MCP Protocol over stdio" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow3" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="mcp-server" target="list-tools" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow5" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="mcp-server" target="tool-router" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow5-label" value="Tool execution request" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow5" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="tool-router" target="nmap-plugin" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow6-label" value="nmap_scan" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow6" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow7" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="tool-router" target="gobuster-plugin" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow7-label" value="gobuster_scan" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow7" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow8" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="tool-router" target="event-retrieval" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow8-label" value="get_scan_events" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow8" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow9" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="nmap-plugin" target="nmap-process" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow9-label" value="Execute scan" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow9" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow13" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="nmap-parser" target="message-broker" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow13-label" value="Generate events" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow13" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow15" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="message-broker" target="event-storage" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow15-label" value="Store events" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow15" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow16" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;strokeWidth=2;" parent="1" source="message-broker" target="event-types-group" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow16-label" value="Publish" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow16" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow17" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="event-retrieval" target="event-storage" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="1070" y="450" />
+              <mxPoint x="1070" y="220" />
+              <mxPoint x="1430" y="220" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow17-label" value="Query events" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow17" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow18" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.75;entryY=0;entryDx=0;entryDy=0;" parent="1" source="event-storage" target="format-response" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow18-label" value="Return filtered events" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow18" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow19" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;curved=1;" parent="1" source="format-response" target="mcp-client" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="20" y="570" />
+              <mxPoint x="20" y="195" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="arrow19-label" value="MCP Response" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="arrow19" vertex="1" connectable="0">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="gobuster-plugin" value="Gobuster Plugin" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="1" vertex="1">
+          <mxGeometry x="340" y="470" width="120" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="PIgsf7xgy3OHlwUPA3rL-1" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="gobuster-plugin" target="nmap-process">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="460" y="500" as="sourcePoint" />
+            <mxPoint x="960" y="120" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="PIgsf7xgy3OHlwUPA3rL-2" value="Execute scan" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="PIgsf7xgy3OHlwUPA3rL-1">
+          <mxGeometry x="-0.1" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/mcp-pentest-flowchart.md
+++ b/mcp-pentest-flowchart.md
@@ -1,0 +1,128 @@
+# MCP Pentest Server - User Interaction & Backend Algorithm Flowchart
+
+## Overview
+This flowchart illustrates the user interaction flow and backend algorithm of the MCP Pentest Server, showing how users interact with the system through Claude Desktop and how the server processes penetration testing tasks.
+
+## Flowchart
+
+```mermaid
+flowchart TB
+    subgraph "User Interface Layer"
+        A[User in Claude Desktop] -->|Request pentesting action| B[Claude AI Assistant]
+        B -->|Generates MCP tool call| C[MCP Client Interface]
+    end
+
+    subgraph "MCP Protocol Layer"
+        C -->|MCP Protocol over stdio| D[MCP Pentest Server]
+        D -->|Tool discovery| E[List Available Tools]
+        E -->|Returns tool definitions| C
+    end
+
+    subgraph "Tool Execution Layer"
+        D -->|Tool execution request| F{Which Tool?}
+
+        F -->|nmap_scan| G[Nmap Plugin]
+        F -->|gobuster_scan| H[Gobuster Plugin]
+        F -->|get_scan_events| I[Event Retrieval]
+
+        G -->|Execute scan| J[Nmap Process]
+        H -->|Execute scan| K[Gobuster Process]
+    end
+
+    subgraph "Event Processing Layer"
+        J -->|Parse output| L[Nmap Output Parser]
+        K -->|Parse output| M[Gobuster Output Parser]
+
+        L -->|Generate events| N[Message Broker]
+        M -->|Generate events| N
+
+        N -->|Store events| O[(Event Storage)]
+    end
+
+    subgraph "Event Types"
+        N -->|Publish| P[HostDiscovered]
+        N -->|Publish| Q[PortFound]
+        N -->|Publish| R[ServiceDetected]
+        N -->|Publish| S[VulnerabilityFound]
+        N -->|Publish| T[WebResourceDiscovered]
+    end
+
+    subgraph "Response Layer"
+        I -->|Query events| O
+        O -->|Return filtered events| U[Format Response]
+        L -->|Success/Failure| U
+        M -->|Success/Failure| U
+
+        U -->|MCP Response| C
+        C -->|Display to user| B
+        B -->|Natural language response| A
+    end
+
+    style A fill:#e1f5e1
+    style D fill:#ffe1e1
+    style N fill:#e1e1ff
+    style O fill:#fff5e1
+```
+
+## Process Flow Description
+
+### 1. User Interaction Flow
+1. **User Request**: User asks Claude Desktop to perform a penetration testing task
+2. **AI Processing**: Claude AI interprets the request and generates appropriate MCP tool calls
+3. **MCP Communication**: Claude Desktop communicates with MCP server via stdio protocol
+
+### 2. Tool Discovery & Selection
+1. **List Tools**: Server provides available tools (nmap_scan, gobuster_scan, get_scan_events)
+2. **Tool Selection**: Based on user request, appropriate tool is selected
+3. **Parameter Validation**: Tool parameters are validated against input schema
+
+### 3. Tool Execution Algorithm
+1. **Plugin Dispatch**: Request is routed to appropriate plugin (Nmap, Gobuster, etc.)
+2. **Command Building**: Plugin constructs command with validated parameters
+3. **Process Execution**: External tool is executed as subprocess
+4. **Output Capture**: stdout/stderr are captured in real-time
+
+### 4. Event Processing Pipeline
+1. **Output Parsing**: Tool output is parsed line-by-line
+2. **Event Generation**: Structured events are created based on findings:
+   - HostDiscovered: New hosts found
+   - PortFound: Open ports detected
+   - ServiceDetected: Services identified
+   - VulnerabilityFound: Security issues discovered
+   - WebResourceDiscovered: Web paths/files found
+3. **Event Publishing**: Events are published to message broker
+4. **Event Storage**: Events are stored for later retrieval
+
+### 5. Response Generation
+1. **Result Aggregation**: Tool execution results and events are collected
+2. **Response Formatting**: Results are formatted with emojis and markdown
+3. **MCP Response**: Formatted response sent back via MCP protocol
+4. **User Display**: Claude Desktop displays results to user
+
+## Key Components
+
+### Message Broker
+- Central event hub for all tool outputs
+- Maintains event history
+- Enables event filtering and querying
+
+### Plugin Architecture
+- Modular design for easy tool addition
+- Each plugin handles:
+  - Command construction
+  - Output parsing
+  - Event generation
+  - Error handling
+
+### Security Considerations
+- Input validation on all parameters
+- Subprocess execution with timeouts
+- No direct shell command execution
+- Sanitized error messages
+
+## Future Enhancements
+- Real-time event streaming
+- Persistent event storage
+- Advanced event correlation
+- Attack path analysis
+- Report generation

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Wrapper script to run MCP pentest server with proper environment
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Activate virtual environment
+if [ -f "$ROOT_DIR/venv310/bin/activate" ]; then
+  source "$ROOT_DIR/venv310/bin/activate"
+elif [ -f "$ROOT_DIR/venv/bin/activate" ]; then
+  source "$ROOT_DIR/venv/bin/activate"
+fi
+
+# Ensure tools are in PATH
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# Run the server
+exec python "$ROOT_DIR/server.py"

--- a/server.py
+++ b/server.py
@@ -32,6 +32,17 @@ import mcp.types as types
 # Import tool plugins
 from tools.network_scanners.nmap_plugin import NmapPlugin
 from tools.web_enumeration.gobuster_plugin import GobusterPlugin
+from tools.web_enumeration.nikto_plugin import NiktoPlugin
+from tools.password_attacks.hydra_plugin import HydraPlugin
+from tools.password_attacks.john_plugin import JohnPlugin
+
+# Metasploit is optional - requires msgpack and requests
+try:
+    from tools.exploitation.metasploit_plugin import MetasploitPlugin
+    METASPLOIT_AVAILABLE = True
+except ImportError:
+    METASPLOIT_AVAILABLE = False
+    MetasploitPlugin = None
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -58,6 +69,17 @@ server = Server("mcp-pentest")
 message_broker = MockMessageBroker()
 nmap_plugin = NmapPlugin(message_broker)
 gobuster_plugin = GobusterPlugin(message_broker)
+nikto_plugin = NiktoPlugin(message_broker)
+hydra_plugin = HydraPlugin(message_broker)
+john_plugin = JohnPlugin(message_broker)
+
+# Metasploit is optional and requires msfrpcd running
+metasploit_plugin = None
+if METASPLOIT_AVAILABLE:
+    try:
+        metasploit_plugin = MetasploitPlugin(message_broker)
+    except Exception as e:
+        logger.warning(f"Metasploit plugin initialization failed (msfrpcd may not be running): {e}")
 
 @server.list_tools()
 async def handle_list_tools() -> list[Tool]:
@@ -163,6 +185,149 @@ async def handle_list_tools() -> list[Tool]:
                     }
                 },
                 "required": []
+            }
+        ),
+        Tool(
+            name="nikto_scan",
+            description="Execute Nikto web server vulnerability scans for misconfigurations and known vulnerabilities",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "target_host": {
+                        "type": "string",
+                        "description": "Target host to scan (IP or hostname)"
+                    },
+                    "port": {
+                        "type": "integer",
+                        "description": "Port to scan",
+                        "default": 80
+                    },
+                    "ssl": {
+                        "type": "boolean",
+                        "description": "Use SSL/HTTPS",
+                        "default": False
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "description": "Scan timeout in seconds",
+                        "default": 7200
+                    }
+                },
+                "required": ["target_host"]
+            }
+        ),
+        Tool(
+            name="hydra_attack",
+            description="Execute Hydra password brute-force attacks against network services (SSH, FTP, HTTP, etc.)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "target_host": {
+                        "type": "string",
+                        "description": "Target host to attack"
+                    },
+                    "protocol": {
+                        "type": "string",
+                        "enum": ["ssh", "ftp", "http-get", "http-post", "smb", "rdp", "mysql", "postgres"],
+                        "description": "Protocol/service to attack"
+                    },
+                    "port": {
+                        "type": "integer",
+                        "description": "Port number (optional, uses default for protocol)"
+                    },
+                    "username": {
+                        "type": "string",
+                        "description": "Single username to test"
+                    },
+                    "userlist": {
+                        "type": "string",
+                        "description": "Path to username list file"
+                    },
+                    "password": {
+                        "type": "string",
+                        "description": "Single password to test"
+                    },
+                    "passlist": {
+                        "type": "string",
+                        "description": "Path to password list file"
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "description": "Attack timeout in seconds",
+                        "default": 3600
+                    }
+                },
+                "required": ["target_host", "protocol"]
+            }
+        ),
+        Tool(
+            name="john_crack",
+            description="Execute John the Ripper offline password hash cracking",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "hash_file": {
+                        "type": "string",
+                        "description": "Path to file containing password hashes"
+                    },
+                    "hash_string": {
+                        "type": "string",
+                        "description": "Single hash string to crack (alternative to hash_file)"
+                    },
+                    "hash_format": {
+                        "type": "string",
+                        "description": "Hash format (e.g., 'md5', 'sha1', 'ntlm', 'bcrypt')"
+                    },
+                    "wordlist": {
+                        "type": "string",
+                        "description": "Path to wordlist file"
+                    },
+                    "max_runtime": {
+                        "type": "integer",
+                        "description": "Maximum runtime in seconds",
+                        "default": 3600
+                    }
+                },
+                "required": []
+            }
+        ),
+        Tool(
+            name="metasploit_exploit",
+            description="Execute Metasploit exploits against targets (requires msfrpcd running)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "exploit_module": {
+                        "type": "string",
+                        "description": "Exploit module path (e.g., 'exploit/windows/smb/ms17_010_eternalblue')"
+                    },
+                    "payload": {
+                        "type": "string",
+                        "description": "Payload to use (e.g., 'windows/x64/meterpreter/reverse_tcp')"
+                    },
+                    "rhosts": {
+                        "type": "string",
+                        "description": "Target host(s)"
+                    },
+                    "rport": {
+                        "type": "integer",
+                        "description": "Target port"
+                    },
+                    "lhost": {
+                        "type": "string",
+                        "description": "Local host for reverse connections"
+                    },
+                    "lport": {
+                        "type": "integer",
+                        "description": "Local port for reverse connections",
+                        "default": 4444
+                    },
+                    "options": {
+                        "type": "object",
+                        "description": "Additional module options as key-value pairs"
+                    }
+                },
+                "required": ["exploit_module", "rhosts"]
             }
         )
     ]
@@ -311,7 +476,138 @@ async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent
         except Exception as e:
             logger.error(f"Error retrieving events: {e}")
             return [types.TextContent(type="text", text=f"❌ Error retrieving events: {str(e)}")]
-    
+
+    elif name == "nikto_scan":
+        try:
+            result = nikto_plugin.execute_task(arguments)
+
+            if result.get('success'):
+                response = f"✅ Nikto scan completed successfully!\n\n"
+                response += f"📊 **Scan Results:**\n"
+                response += f"- Return code: {result.get('return_code', 'N/A')}\n"
+                response += f"- Events generated: {result.get('event_count', 0)}\n"
+                response += f"- Scan time: {result.get('scan_time', 'N/A')}\n"
+
+                # Add summary of vulnerabilities found
+                recent_events = [e for e in message_broker.events if e['topic'] == 'tool_events' and e['message'].get('event_type') == 'VulnerabilityFound'][-20:]
+                if recent_events:
+                    response += f"\n⚠️ **Vulnerabilities Found:**\n"
+                    for event in recent_events:
+                        msg = event['message']
+                        vuln = msg.get('vulnerability', 'Unknown')
+                        severity = msg.get('severity', 'N/A')
+                        response += f"- [{severity}] {vuln}\n"
+            else:
+                response = f"❌ Nikto scan failed!\n\n"
+                response += f"- Return code: {result.get('return_code', 'N/A')}\n"
+                if result.get('error'):
+                    response += f"- Error: {result.get('error')}\n"
+
+            return [types.TextContent(type="text", text=response)]
+
+        except Exception as e:
+            logger.error(f"Error executing nikto scan: {e}")
+            return [types.TextContent(type="text", text=f"❌ Error executing nikto scan: {str(e)}")]
+
+    elif name == "hydra_attack":
+        try:
+            result = hydra_plugin.execute_task(arguments)
+
+            if result.get('success'):
+                response = f"✅ Hydra attack completed!\n\n"
+                response += f"📊 **Attack Results:**\n"
+                response += f"- Return code: {result.get('return_code', 'N/A')}\n"
+                response += f"- Events generated: {result.get('event_count', 0)}\n"
+                response += f"- Attack time: {result.get('scan_time', 'N/A')}\n"
+
+                # Add summary of credentials found
+                recent_events = [e for e in message_broker.events if e['topic'] == 'tool_events' and e['message'].get('event_type') == 'CredentialFound'][-20:]
+                if recent_events:
+                    response += f"\n🔑 **Credentials Found:**\n"
+                    for event in recent_events:
+                        msg = event['message']
+                        username = msg.get('username', 'Unknown')
+                        password = msg.get('password', 'Unknown')
+                        host = msg.get('host', 'Unknown')
+                        response += f"- {username}:{password} @ {host}\n"
+                else:
+                    response += "\nNo credentials cracked.\n"
+            else:
+                response = f"❌ Hydra attack failed!\n\n"
+                response += f"- Return code: {result.get('return_code', 'N/A')}\n"
+                if result.get('error'):
+                    response += f"- Error: {result.get('error')}\n"
+
+            return [types.TextContent(type="text", text=response)]
+
+        except Exception as e:
+            logger.error(f"Error executing hydra attack: {e}")
+            return [types.TextContent(type="text", text=f"❌ Error executing hydra attack: {str(e)}")]
+
+    elif name == "john_crack":
+        try:
+            result = john_plugin.execute_task(arguments)
+
+            if result.get('success'):
+                response = f"✅ John the Ripper completed!\n\n"
+                response += f"📊 **Cracking Results:**\n"
+                response += f"- Return code: {result.get('return_code', 'N/A')}\n"
+                response += f"- Events generated: {result.get('event_count', 0)}\n"
+                response += f"- Crack time: {result.get('scan_time', 'N/A')}\n"
+
+                # Add summary of cracked passwords
+                recent_events = [e for e in message_broker.events if e['topic'] == 'tool_events' and e['message'].get('event_type') == 'PasswordCracked'][-20:]
+                if recent_events:
+                    response += f"\n🔓 **Cracked Passwords:**\n"
+                    for event in recent_events:
+                        msg = event['message']
+                        hash_val = msg.get('hash', 'Unknown')[:20] + '...'
+                        password = msg.get('password', 'Unknown')
+                        response += f"- {hash_val} => {password}\n"
+                else:
+                    response += "\nNo passwords cracked.\n"
+            else:
+                response = f"❌ John the Ripper failed!\n\n"
+                response += f"- Return code: {result.get('return_code', 'N/A')}\n"
+                if result.get('error'):
+                    response += f"- Error: {result.get('error')}\n"
+
+            return [types.TextContent(type="text", text=response)]
+
+        except Exception as e:
+            logger.error(f"Error executing john crack: {e}")
+            return [types.TextContent(type="text", text=f"❌ Error executing john crack: {str(e)}")]
+
+    elif name == "metasploit_exploit":
+        if metasploit_plugin is None:
+            return [types.TextContent(type="text", text="❌ Metasploit plugin not available. Ensure msfrpcd is running.")]
+
+        try:
+            result = metasploit_plugin.execute_task(arguments)
+
+            if result.get('success'):
+                response = f"✅ Metasploit exploit executed!\n\n"
+                response += f"📊 **Exploit Results:**\n"
+                response += f"- Module: {arguments.get('exploit_module', 'N/A')}\n"
+                response += f"- Target: {arguments.get('rhosts', 'N/A')}\n"
+                response += f"- Events generated: {result.get('event_count', 0)}\n"
+
+                # Add session info if available
+                if result.get('session_id'):
+                    response += f"\n🎯 **Session Opened!**\n"
+                    response += f"- Session ID: {result.get('session_id')}\n"
+                    response += f"- Session Type: {result.get('session_type', 'N/A')}\n"
+            else:
+                response = f"❌ Metasploit exploit failed!\n\n"
+                if result.get('error'):
+                    response += f"- Error: {result.get('error')}\n"
+
+            return [types.TextContent(type="text", text=response)]
+
+        except Exception as e:
+            logger.error(f"Error executing metasploit exploit: {e}")
+            return [types.TextContent(type="text", text=f"❌ Error executing metasploit exploit: {str(e)}")]
+
     else:
         return [types.TextContent(type="text", text=f"❌ Unknown tool: {name}")]
 

--- a/simple_nmap_test.py
+++ b/simple_nmap_test.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""
+Simple test to verify nmap is working directly
+"""
+
+import subprocess
+import json
+
+def test_nmap_direct():
+    """Test nmap directly without MCP"""
+    print("Testing nmap directly...")
+
+    # Simple nmap command
+    cmd = ["nmap", "-p", "22,80,443", "--open", "127.0.0.1"]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        print(f"Return code: {result.returncode}")
+        print(f"\nOutput:\n{result.stdout}")
+        if result.stderr:
+            print(f"\nErrors:\n{result.stderr}")
+    except subprocess.TimeoutExpired:
+        print("Nmap scan timed out after 30 seconds")
+    except Exception as e:
+        print(f"Error running nmap: {e}")
+
+if __name__ == "__main__":
+    test_nmap_direct()

--- a/test_mcp_server.py
+++ b/test_mcp_server.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Test script to verify MCP server functionality with nmap
+"""
+
+import asyncio
+import json
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+async def test_nmap_scan():
+    """Test nmap functionality through MCP server"""
+    
+    # Create server parameters for the MCP pentest server
+    server_params = StdioServerParameters(
+        command="/Users/Shayaun.Nejad/Code/mcp-pentest/venv310/bin/python",
+        args=["/Users/Shayaun.Nejad/Code/mcp-pentest/server.py"],
+        env={"PATH": "/Users/Shayaun.Nejad/Code/mcp-pentest/venv310/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"}
+    )
+    
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            # Initialize the connection
+            await session.initialize()
+            
+            # List available tools
+            print("Available tools:")
+            tools_result = await session.list_tools()
+            for tool in tools_result.tools:
+                print(f"  - {tool.name}: {tool.description}")
+            
+            # Test nmap scan on localhost
+            print("\nTesting nmap scan on localhost...")
+            result = await session.call_tool(
+                "nmap_scan",
+                arguments={
+                    "targets": "127.0.0.1",
+                    "scan_type": "quick",
+                    "ports": "80,443,22",
+                    "timeout": 30
+                }
+            )
+            
+            print("\nScan result:")
+            for content in result.content:
+                if hasattr(content, 'text'):
+                    print(content.text)
+
+            # Get scan events
+            print("\nRetrieving scan events...")
+            events_result = await session.call_tool(
+                "get_scan_events",
+                arguments={
+                    "limit": 10
+                }
+            )
+
+            print("\nScan events:")
+            for content in events_result.content:
+                if hasattr(content, 'text'):
+                    print(content.text)
+
+if __name__ == "__main__":
+    asyncio.run(test_nmap_scan())

--- a/test_nmap_simple.py
+++ b/test_nmap_simple.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Simple test for nmap plugin without MCP dependencies
+"""
+
+import sys
+import os
+from pathlib import Path
+
+# Add the project root to the Python path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from tools.network_scanners.nmap_plugin import NmapPlugin
+
+class MockMessageBroker:
+    """Mock message broker for testing"""
+    def __init__(self):
+        self.published_messages = []
+
+    def publish(self, topic, message):
+        self.published_messages.append({'topic': topic, 'message': message})
+        print(f"📢 Published to {topic}: {message.get('event_type', 'Unknown')}")
+
+def test_nmap_basic():
+    """Test basic nmap functionality"""
+    print("=" * 60)
+    print("🔍 Testing Nmap Plugin - Basic Functionality")
+    print("=" * 60)
+
+    # Initialize plugin
+    broker = MockMessageBroker()
+    plugin = NmapPlugin(broker)
+
+    # Test capabilities
+    capabilities = plugin.get_capabilities()
+    print(f"✅ Plugin capabilities: {capabilities}")
+
+    # Test a basic scan on localhost
+    print("\n🎯 Running basic nmap scan on localhost (127.0.0.1)...")
+    task_params = {
+        'targets': '127.0.0.1',
+        'scan_type': 'basic',
+        'ports': '22,80,443,8080',
+        'engagement_id': 'test-engagement-001'
+    }
+
+    try:
+        result = plugin.execute_task(task_params)
+        print(f"\n📊 Scan Result:")
+        print(f"   Return Code: {result.get('return_code', 'N/A')}")
+        print(f"   Success: {result.get('success', False)}")
+        print(f"   Event Count: {result.get('event_count', 0)}")
+        print(f"   Scan Time: {result.get('scan_time', 'N/A')}")
+
+        if result.get('output_file'):
+            print(f"   Output File: {result.get('output_file')}")
+
+        if result.get('error'):
+            print(f"   Error: {result.get('error')}")
+
+        # Show published events
+        if broker.published_messages:
+            print(f"\n🎯 Published Events ({len(broker.published_messages)}):")
+            for i, msg in enumerate(broker.published_messages, 1):
+                if msg['topic'] == 'tool_events':
+                    event = msg['message']
+                    event_type = event.get('event_type', 'Unknown')
+                    print(f"   {i}. {event_type}")
+
+                    if event_type == 'HostDiscovered':
+                        print(f"      IP: {event.get('ip', 'N/A')}")
+                        print(f"      Hostname: {event.get('hostname', 'N/A')}")
+                    elif event_type == 'PortFound':
+                        print(f"      IP: {event.get('ip', 'N/A')}")
+                        print(f"      Port: {event.get('port', 'N/A')}/{event.get('protocol', 'N/A')}")
+                    elif event_type == 'ServiceDetected':
+                        print(f"      IP: {event.get('ip', 'N/A')}")
+                        print(f"      Port: {event.get('port', 'N/A')}")
+                        print(f"      Service: {event.get('service', 'N/A')}")
+                        print(f"      Product: {event.get('product', 'N/A')}")
+                        print(f"      Version: {event.get('version', 'N/A')}")
+                    elif event_type == 'VulnerabilityFound':
+                        print(f"      IP: {event.get('ip', 'N/A')}")
+                        print(f"      Port: {event.get('port', 'N/A')}")
+                        print(f"      Vulnerability: {event.get('vulnerability', 'N/A')}")
+                        print(f"      Severity: {event.get('severity', 'N/A')}")
+
+        return result.get('success', False)
+
+    except Exception as e:
+        print(f"❌ Error during nmap test: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def test_nmap_parsing():
+    """Test nmap XML parsing functionality"""
+    print("\n" + "=" * 60)
+    print("🔍 Testing Nmap Plugin - XML Parsing")
+    print("=" * 60)
+
+    broker = MockMessageBroker()
+    plugin = NmapPlugin(broker)
+
+    # Sample nmap XML output for testing
+    sample_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<nmaprun scanner="nmap" args="nmap -sS -p22,80,443 127.0.0.1" start="1704067200" startstr="Mon Jan 01 00:00:00 2024" version="7.80" xmloutputversion="1.04">
+<host starttime="1704067200" endtime="1704067201">
+<status state="up" reason="echo-reply" reason_ttl="64"/>
+<address addr="127.0.0.1" addrtype="ipv4"/>
+<hostnames>
+<hostname name="localhost" type="PTR"/>
+</hostnames>
+<ports>
+<port protocol="tcp" portid="22">
+<state state="open" reason="syn-ack" reason_ttl="64"/>
+<service name="ssh" product="OpenSSH" version="8.9" method="probed" conf="10"/>
+</port>
+<port protocol="tcp" portid="80">
+<state state="closed" reason="reset" reason_ttl="64"/>
+</port>
+<port protocol="tcp" portid="443">
+<state state="open" reason="syn-ack" reason_ttl="64"/>
+<service name="https" product="nginx" version="1.18.0" method="probed" conf="10"/>
+</port>
+</ports>
+</host>
+<runstats>
+<finished time="1704067201" timestr="Mon Jan 01 00:00:01 2024" elapsed="1.0" summary="Nmap done at Mon Jan 01 00:00:01 2024; 1 IP address (1 host up) scanned in 1.0 seconds" exit="success"/>
+</runstats>
+</nmaprun>"""
+
+    print("🔍 Parsing sample nmap XML...")
+    events = plugin.parse_output(sample_xml)
+
+    print(f"✅ Parsed {len(events)} events from sample XML")
+
+    # Group events by type
+    event_types = {}
+    for event in events:
+        event_type = event.get('event_type', 'Unknown')
+        if event_type not in event_types:
+            event_types[event_type] = []
+        event_types[event_type].append(event)
+
+    print(f"\n📋 Event Summary:")
+    for event_type, event_list in event_types.items():
+        print(f"   {event_type}: {len(event_list)} events")
+
+    print(f"\n📝 Detailed Events:")
+    for i, event in enumerate(events, 1):
+        event_type = event.get('event_type', 'Unknown')
+        print(f"   {i}. {event_type}")
+
+        if event_type == 'HostDiscovered':
+            print(f"      IP: {event.get('ip', 'N/A')}")
+            print(f"      Hostname: {event.get('hostname', 'N/A')}")
+        elif event_type == 'PortFound':
+            print(f"      IP: {event.get('ip', 'N/A')}")
+            print(f"      Port: {event.get('port', 'N/A')}/{event.get('protocol', 'N/A')}")
+        elif event_type == 'ServiceDetected':
+            print(f"      IP: {event.get('ip', 'N/A')}")
+            print(f"      Port: {event.get('port', 'N/A')}")
+            print(f"      Service: {event.get('service', 'N/A')}")
+            print(f"      Product: {event.get('product', 'N/A')}")
+            print(f"      Version: {event.get('version', 'N/A')}")
+
+    return len(events) > 0
+
+if __name__ == "__main__":
+    print("🚀 Starting Nmap Plugin Tests...")
+
+    # Test parsing first (doesn't require external tools)
+    parsing_success = test_nmap_parsing()
+
+    # Test actual nmap execution
+    execution_success = test_nmap_basic()
+
+    print("\n" + "=" * 60)
+    print("📊 Test Summary")
+    print("=" * 60)
+    print(f"XML Parsing: {'✅ PASS' if parsing_success else '❌ FAIL'}")
+    print(f"Nmap Execution: {'✅ PASS' if execution_success else '❌ FAIL'}")
+
+    if parsing_success and execution_success:
+        print("\n🎉 All tests passed! The nmap plugin is working correctly.")
+    elif parsing_success:
+        print("\n⚠️  XML parsing works, but nmap execution failed. Check if nmap is installed and accessible.")
+    else:
+        print("\n❌ Tests failed. Please check the error messages above.")

--- a/test_plugins.py
+++ b/test_plugins.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Test script for nmap and gobuster plugins
+"""
+
+import sys
+import os
+import subprocess
+from pathlib import Path
+
+# Add the project root to the Python path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from tools.network_scanners.nmap_plugin import NmapPlugin
+from tools.web_enumeration.gobuster_plugin import GobusterPlugin
+
+class MockMessageBroker:
+    """Mock message broker for testing"""
+    def __init__(self):
+        self.published_messages = []
+
+    def publish(self, topic, message):
+        self.published_messages.append({'topic': topic, 'message': message})
+        print(f"Published to {topic}: {message.get('event_type', 'Unknown')}")
+
+def test_nmap_plugin():
+    """Test the nmap plugin"""
+    print("=" * 50)
+    print("Testing Nmap Plugin")
+    print("=" * 50)
+
+    # Check if nmap is available
+    try:
+        result = subprocess.run(['nmap', '--version'], capture_output=True, text=True)
+        if result.returncode != 0:
+            print("Nmap not available, skipping test")
+            return False
+        print(f"Nmap version: {result.stdout.split()[2]}")
+    except FileNotFoundError:
+        print("Nmap not found in PATH, skipping test")
+        return False
+
+    # Initialize plugin
+    broker = MockMessageBroker()
+    plugin = NmapPlugin(broker)
+
+    # Test capabilities
+    capabilities = plugin.get_capabilities()
+    print(f"Capabilities: {capabilities}")
+
+    # Test a simple scan (localhost)
+    task_params = {
+        'targets': '127.0.0.1',
+        'scan_type': 'basic',
+        'ports': '22,80,443',
+        'engagement_id': 'test-engagement'
+    }
+
+    print("Running basic nmap scan on localhost...")
+    try:
+        result = plugin.execute_task(task_params)
+        print(f"Scan result: {result}")
+
+        if result.get('success'):
+            print(f"Event count: {result.get('event_count', 0)}")
+            print("Published events:")
+            for msg in broker.published_messages:
+                if msg['topic'] == 'tool_events':
+                    event = msg['message']
+                    print(f"  - {event['event_type']}: {event}")
+        else:
+            print(f"Scan failed: {result}")
+
+        return result.get('success', False)
+    except Exception as e:
+        print(f"Error during nmap test: {e}")
+        return False
+
+def test_gobuster_plugin():
+    """Test the gobuster plugin"""
+    print("=" * 50)
+    print("Testing Gobuster Plugin")
+    print("=" * 50)
+
+    # Check if gobuster is available
+    try:
+        result = subprocess.run(['gobuster', 'version'], capture_output=True, text=True)
+        if result.returncode != 0:
+            print("Gobuster not available, skipping test")
+            return False
+        print(f"Gobuster output: {result.stdout}")
+    except FileNotFoundError:
+        print("Gobuster not found in PATH, skipping test")
+        return False
+
+    # Initialize plugin
+    broker = MockMessageBroker()
+    plugin = GobusterPlugin(broker)
+
+    # Test capabilities
+    capabilities = plugin.get_capabilities()
+    print(f"Capabilities: {capabilities}")
+
+    # Test a simple directory scan (using httpbin.org as a safe test target)
+    task_params = {
+        'target_url': 'https://httpbin.org',
+        'mode': 'dir',
+        'wordlist': '/usr/share/wordlists/dirb/common.txt',  # This may not exist
+        'threads': 5,
+        'engagement_id': 'test-engagement'
+    }
+
+    print("Running basic gobuster scan on httpbin.org...")
+    try:
+        result = plugin.execute_task(task_params)
+        print(f"Scan result: {result}")
+
+        if result.get('success'):
+            print(f"Event count: {result.get('event_count', 0)}")
+            print("Published events:")
+            for msg in broker.published_messages:
+                if msg['topic'] == 'tool_events':
+                    event = msg['message']
+                    print(f"  - {event['event_type']}: {event}")
+        else:
+            print(f"Scan failed: {result}")
+
+        return result.get('success', False)
+    except Exception as e:
+        print(f"Error during gobuster test: {e}")
+        return False
+
+def test_parsing():
+    """Test parsing functionality"""
+    print("=" * 50)
+    print("Testing Parsing Functions")
+    print("=" * 50)
+
+    # Test nmap XML parsing
+    broker = MockMessageBroker()
+    nmap_plugin = NmapPlugin(broker)
+
+    # Sample nmap XML output
+    sample_nmap_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<nmaprun scanner="nmap" args="nmap -sS -p22,80,443 127.0.0.1" start="1234567890" startstr="Mon Jan 01 00:00:00 2024" version="7.80" xmloutputversion="1.04">
+<host starttime="1234567890" endtime="1234567891">
+<status state="up" reason="echo-reply" reason_ttl="64"/>
+<address addr="127.0.0.1" addrtype="ipv4"/>
+<hostnames>
+<hostname name="localhost" type="PTR"/>
+</hostnames>
+<ports>
+<port protocol="tcp" portid="22">
+<state state="open" reason="syn-ack" reason_ttl="64"/>
+<service name="ssh" product="OpenSSH" version="8.9" method="probed" conf="10"/>
+</port>
+<port protocol="tcp" portid="80">
+<state state="closed" reason="reset" reason_ttl="64"/>
+</port>
+</ports>
+</host>
+<runstats>
+<finished time="1234567891" timestr="Mon Jan 01 00:00:01 2024" elapsed="1.0" summary="Nmap done at Mon Jan 01 00:00:01 2024; 1 IP address (1 host up) scanned in 1.0 seconds" exit="success"/>
+</runstats>
+</nmaprun>"""
+
+    print("Testing nmap XML parsing...")
+    events = nmap_plugin.parse_output(sample_nmap_xml)
+    print(f"Parsed {len(events)} events from sample nmap output")
+    for event in events:
+        print(f"  - {event['event_type']}: {event}")
+
+    # Test gobuster text parsing
+    gobuster_plugin = GobusterPlugin(broker)
+
+    sample_gobuster_output = """/admin (Status: 301) [Size: 169]
+/api (Status: 200) [Size: 1234]
+/login (Status: 200) [Size: 5678]
+/notfound (Status: 404) [Size: 0]"""
+
+    print("\nTesting gobuster text parsing...")
+    events = gobuster_plugin.parse_output(sample_gobuster_output, target_url="https://example.com")
+    print(f"Parsed {len(events)} events from sample gobuster output")
+    for event in events:
+        print(f"  - {event['event_type']}: {event}")
+
+if __name__ == "__main__":
+    print("Starting plugin tests...")
+
+    # Test parsing first (doesn't require external tools)
+    test_parsing()
+
+    # Test actual tool execution
+    nmap_success = test_nmap_plugin()
+    gobuster_success = test_gobuster_plugin()
+
+    print("\n" + "=" * 50)
+    print("Test Summary")
+    print("=" * 50)
+    print(f"Nmap plugin: {'PASS' if nmap_success else 'FAIL'}")
+    print(f"Gobuster plugin: {'PASS' if gobuster_success else 'FAIL'}")

--- a/tools/network_scanners/nmap_plugin.py
+++ b/tools/network_scanners/nmap_plugin.py
@@ -98,9 +98,11 @@ class NmapPlugin(BasePlugin):
             # Aggressive scan: -A -T4
             command.extend(['-sT', '-A', '-T4'])
         elif scan_type == 'quick':
-            # Quick scan: -T4 -F (fast scan)
-            command.extend(['-sT', '-T4', '-F'])
-        
+            # Quick scan: -T4 (fast timing), -F only if no ports specified
+            command.extend(['-sT', '-T4'])
+            if not ports:
+                command.append('-F')  # Fast scan (top 100 ports) only when no ports specified
+
         # Add port specification if provided
         if ports:
             command.extend(['-p', ports])

--- a/tools/web_enumeration/nikto_plugin.py
+++ b/tools/web_enumeration/nikto_plugin.py
@@ -137,7 +137,31 @@ class NiktoPlugin(BasePlugin):
                 result['success'] = False
         
         return result
-    
+
+    def parse_output(self, output_data: Union[str, bytes], target_host: str = "", port: int = 80) -> List[Dict]:
+        """
+        Parse Nikto output into standardized events.
+
+        Args:
+            output_data: Nikto output (XML, CSV, or text)
+            target_host: The target host that was scanned
+            port: The port that was scanned
+
+        Returns:
+            List[Dict]: List of events generated from the Nikto output
+        """
+        if isinstance(output_data, bytes):
+            output_data = output_data.decode('utf-8', errors='ignore')
+
+        # Try to detect format and parse accordingly
+        if output_data.strip().startswith('<?xml') or output_data.strip().startswith('<'):
+            return self.parse_xml_output(output_data, target_host, port)
+        elif ',' in output_data and '\n' in output_data:
+            # Likely CSV
+            return self.parse_csv_output(output_data, target_host, port)
+        else:
+            return self.parse_text_output(output_data, target_host, port)
+
     def parse_xml_output(self, xml_content: str, target_host: str, port: int) -> List[Dict]:
         """
         Parse Nikto XML output into standardized events.


### PR DESCRIPTION
## Summary

- Wire up all 6 tool plugins in server.py (nikto, hydra, john, metasploit were missing)
- Make metasploit import optional for graceful degradation
- Fix nmap quick scan bug (`-F` conflicts with `-p`)
- Add missing `parse_output` method to NiktoPlugin
- Update README to accurately reflect current functionality
- Add end-to-end MCP test script

## All 7 MCP tools now work

| Tool | Status |
|------|--------|
| `nmap_scan` | ✅ Tested |
| `gobuster_scan` | ✅ Wired up |
| `nikto_scan` | ✅ Wired up |
| `hydra_attack` | ✅ Tested |
| `john_crack` | ✅ Wired up |
| `metasploit_exploit` | ✅ Wired up (optional) |
| `get_scan_events` | ✅ Tested |

## Test plan

- [x] Server imports successfully
- [x] All 7 tools listed via MCP protocol
- [x] Nmap scan executes and returns structured events
- [x] Events retrievable via `get_scan_events`
- [x] Tested on real target (HTB CTF box)